### PR TITLE
MS SQL Server docker image downgrade

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -21,15 +21,6 @@ services:
         start_period: 10s
         timeout: 3s
 
-  backend.webapp:
-    container_name: backend.webapp
-    build: 
-      context: .
-      dockerfile: Dockerfile.webapp
-    depends_on:
-      backend.db:
-        condition: service_healthy
-
   backend.api:
     container_name: backend.api
     build:
@@ -40,9 +31,18 @@ services:
     ports:
       - 8080:8080
     depends_on:
-      backend.webapp:
-        condition: service_completed_successfully
+      backend.db:
+        condition: service_healthy
   
+  backend.webapp:
+    container_name: backend.webapp
+    build: 
+      context: .
+      dockerfile: Dockerfile.webapp
+    depends_on:
+      backend.api:
+        condition: service_started
+
   backend.mvc:
     container_name: backend.mvc
     build:
@@ -54,7 +54,7 @@ services:
       - 8081:8080
     depends_on:
       backend.webapp:
-        condition: service_completed_successfully
+        condition: service_started
     profiles:
       - 'mvc'
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,7 @@
 services:
   backend.db:
     container_name: backend.db
-    image: mcr.microsoft.com/mssql/server:2019-latest
+    image: mcr.microsoft.com/mssql/server:2019-CU26-ubuntu-20.04
     environment:
       - ACCEPT_EULA=y
       - SA_PASSWORD=pass_123


### PR DESCRIPTION
- `2019-latest` image got a recent update which causes our existing db-init.sh script to fail.
- So, I downgraded it to an older version - `2019-CU26-ubuntu-20.04` which works well with our existing setup.